### PR TITLE
Make express loader behave as expected

### DIFF
--- a/lib/loaders/express.loader.ts
+++ b/lib/loaders/express.loader.ts
@@ -16,10 +16,7 @@ export class ExpressLoader extends AbstractLoader {
     );
     const clientPath = options.rootPath;
     const indexFilePath = this.getIndexFilePath(clientPath);
-
-    app.use(express.static(clientPath, options.serveStaticOptions));
-    app.get(options.renderPath, (req: any, res: any) =>
-      res.sendFile(indexFilePath)
-    );
+      
+    app.use(options.renderPath, express.static(clientPath, options.serveStaticOptions));
   }
 }


### PR DESCRIPTION
If I pass a render path, I still want the default behaviour of `express.static()` on said path

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information