### PR TITLE
fix(): check for null httpadapter

### DIFF
--- a/lib/serve-static.providers.ts
+++ b/lib/serve-static.providers.ts
@@ -9,7 +9,7 @@ export const serveStaticProviders: Provider[] = [
   {
     provide: AbstractLoader,
     useFactory: (httpAdapterHost: HttpAdapterHost) => {
-      if (!httpAdapterHost) {
+      if (!httpAdapterHost || !httpAdapterHost.httpAdapter) {
         return new NoopLoader();
       }
       const httpAdapter = httpAdapterHost.httpAdapter;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

When creating a standalone application using `NestFactory.createApplicationContext(AppModule)` `ExpressLoader.register` throws an exception because the httpAdapter is null.

`serveStaticProviders` will  return a `NoopLoader` if `httpAdapterHost` is `null`, but in this case `httpAdapterHost` is equal to `{ _httpAdapter: null }`. I made a change to `serveStaticProviders` so that it will return the `NoopLoader` when httpAdapterHost equals `{ _httpAdapter: null }`.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

NestJS 7.0.9
@nestjs/serve-static 2.1.0
