### PR TITLE
fix(status): Send response with 404 when ENOENT is found

### DIFF
--- a/lib/loaders/express.loader.ts
+++ b/lib/loaders/express.loader.ts
@@ -58,7 +58,7 @@ export class ExpressLoader extends AbstractLoader {
       }
 
       app.use((err: Error, req, res, next: Function) => {
-        if (err.message.includes('ENOENT')) {
+        if (err.message != undefined && err.message.includes('ENOENT')) {
           res.setStatus(HttpStatus.NOT_FOUND);
         }
 

--- a/lib/loaders/express.loader.ts
+++ b/lib/loaders/express.loader.ts
@@ -1,4 +1,4 @@
-import { Injectable, HttpStatus } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import * as fs from 'fs';
 import { AbstractHttpAdapter } from '@nestjs/core';
@@ -58,7 +58,7 @@ export class ExpressLoader extends AbstractLoader {
       }
 
       app.use((err: Error, req, res, next: Function) => {
-        if (err.message != undefined && err.message.includes('ENOENT')) {
+        if (err?.message?.includes('ENOENT')) {
           return res.send(new NotFoundException(err.message));
         }
 

--- a/lib/loaders/express.loader.ts
+++ b/lib/loaders/express.loader.ts
@@ -35,7 +35,12 @@ export class ExpressLoader extends AbstractLoader {
             const stat = fs.statSync(indexFilePath);
             options.serveStaticOptions.setHeaders(res, indexFilePath, stat);
           }
-          res.sendFile(indexFilePath);
+          res.sendFile(indexFilePath, null, (err: Error) => {
+            if (err) {
+              const error = new NotFoundException(err.message);
+              res.status(error.getStatus()).send(error.getResponse());
+            }
+          });
         } else {
           next();
         }
@@ -56,14 +61,6 @@ export class ExpressLoader extends AbstractLoader {
         app.use(express.static(clientPath, options.serveStaticOptions));
         app.get(options.renderPath, renderFn);
       }
-
-      app.use((err: Error, req, res, next: Function) => {
-        if (err?.message?.includes('ENOENT')) {
-          return res.send(new NotFoundException(err.message));
-        }
-
-        next(err);
-      });
     });
   }
 }

--- a/lib/loaders/express.loader.ts
+++ b/lib/loaders/express.loader.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, HttpStatus } from '@nestjs/common';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import * as fs from 'fs';
 import { AbstractHttpAdapter } from '@nestjs/core';
@@ -21,7 +21,7 @@ export class ExpressLoader extends AbstractLoader {
     const express = loadPackage('express', 'ServeStaticModule', () =>
       require('express')
     );
-    optionsArr.forEach(options => {
+    optionsArr.forEach((options) => {
       options.renderPath = options.renderPath || DEFAULT_RENDER_PATH;
       const clientPath = options.rootPath || DEFAULT_ROOT_PATH;
       const indexFilePath = this.getIndexFilePath(clientPath);
@@ -56,6 +56,14 @@ export class ExpressLoader extends AbstractLoader {
         app.use(express.static(clientPath, options.serveStaticOptions));
         app.get(options.renderPath, renderFn);
       }
+
+      app.use((err: Error, req, res, next: Function) => {
+        if (err.message.includes('ENOENT')) {
+          res.setStatus(HttpStatus.NOT_FOUND);
+        }
+
+        next(err);
+      });
     });
   }
 }

--- a/lib/loaders/express.loader.ts
+++ b/lib/loaders/express.loader.ts
@@ -59,7 +59,7 @@ export class ExpressLoader extends AbstractLoader {
 
       app.use((err: Error, req, res, next: Function) => {
         if (err.message != undefined && err.message.includes('ENOENT')) {
-          res.setStatus(HttpStatus.NOT_FOUND);
+          return res.send(new NotFoundException(err.message));
         }
 
         next(err);

--- a/lib/loaders/fastify.loader.ts
+++ b/lib/loaders/fastify.loader.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
 import { AbstractHttpAdapter } from '@nestjs/core';
 import * as fs from 'fs';
@@ -23,11 +23,30 @@ export class FastifyLoader extends AbstractLoader {
       () => require('fastify-static')
     );
 
-    optionsArr.forEach(options => {
+    optionsArr.forEach((options) => {
       options.renderPath = options.renderPath || DEFAULT_RENDER_PATH;
 
       const clientPath = options.rootPath || DEFAULT_ROOT_PATH;
       const indexFilePath = this.getIndexFilePath(clientPath);
+
+      const renderFn = (req: any, res: any) => {
+        fs.exists(indexFilePath, (exists: boolean) => {
+          if (exists) {
+            const stream = fs.createReadStream(indexFilePath);
+            if (
+              options.serveStaticOptions &&
+              options.serveStaticOptions.setHeaders
+            ) {
+              const stat = fs.statSync(indexFilePath);
+              options.serveStaticOptions.setHeaders(res, indexFilePath, stat);
+            }
+            res.type('text/html').send(stream);
+          } else {
+            const error = new NotFoundException();
+            res.status(error.getStatus()).send(error.getResponse());
+          }
+        });
+      };
 
       if (options.serveRoot) {
         app.register(fastifyStatic, {
@@ -42,27 +61,14 @@ export class FastifyLoader extends AbstractLoader {
             ? options.serveRoot + validatePath(options.renderPath as string)
             : options.serveRoot;
 
-        app.get(renderPath, (req: any, res: any) => {
-          const stream = fs.createReadStream(indexFilePath);
-          res.type('text/html').send(stream);
-        });
+        app.get(renderPath, renderFn);
       } else {
         app.register(fastifyStatic, {
           root: clientPath,
           ...(options.serveStaticOptions || {}),
           wildcard: false
         });
-        app.get(options.renderPath, (req: any, res: any) => {
-          const stream = fs.createReadStream(indexFilePath);
-          if (
-            options.serveStaticOptions &&
-            options.serveStaticOptions.setHeaders
-          ) {
-            const stat = fs.statSync(indexFilePath);
-            options.serveStaticOptions.setHeaders(res, indexFilePath, stat);
-          }
-          res.type('text/html').send(stream);
-        });
+        app.get(options.renderPath, renderFn);
       }
     });
   }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #139 


## What is the new behavior?

Sends the response back with a 404 when ENOENT is included in the error message.

## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Maybe it is a breaking change. If you are someone who is catching 500 level errors in a catch all interceptor and checking for ENOENT existence in your error message, then chances are you would be affected by this change.