### PR TITLE
feat(): apply headers to index.html served as fallback, close #242

### DIFF
--- a/lib/loaders/express.loader.ts
+++ b/lib/loaders/express.loader.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { loadPackage } from '@nestjs/common/utils/load-package.util';
+import * as fs from 'fs';
 import { AbstractHttpAdapter } from '@nestjs/core';
 import { ServeStaticModuleOptions } from '../interfaces/serve-static-options.interface';
 import {
@@ -27,6 +28,13 @@ export class ExpressLoader extends AbstractLoader {
 
       const renderFn = (req: unknown, res: any, next: Function) => {
         if (!isRouteExcluded(req, options.exclude)) {
+          if (
+            options.serveStaticOptions &&
+            options.serveStaticOptions.setHeaders
+          ) {
+            const stat = fs.statSync(indexFilePath);
+            options.serveStaticOptions.setHeaders(res, indexFilePath, stat);
+          }
           res.sendFile(indexFilePath);
         } else {
           next();

--- a/lib/loaders/fastify.loader.ts
+++ b/lib/loaders/fastify.loader.ts
@@ -54,6 +54,13 @@ export class FastifyLoader extends AbstractLoader {
         });
         app.get(options.renderPath, (req: any, res: any) => {
           const stream = fs.createReadStream(indexFilePath);
+          if (
+            options.serveStaticOptions &&
+            options.serveStaticOptions.setHeaders
+          ) {
+            const stat = fs.statSync(indexFilePath);
+            options.serveStaticOptions.setHeaders(res, indexFilePath, stat);
+          }
           res.type('text/html').send(stream);
         });
       }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
The `ServeStaticModule` serves `index.html` in various situations

1. `/context-path`  - will redirect using 301 and serve idnex from `/contex-path/`
2. `/context-path/` - will serve index.html using `express.static(clientPath, options.serveStaticOptions)` so we can use `setHeaders` method to apply custom headers
3. `/context-path/some/path/that/falls/back/to/index` - will serve index.html using `app.get(renderPath, renderFn);` and more preciselly `res.sendFile(indexFilePath);` to which the `serveStaticOptions` are NOT applied

Issue Number: 242


## What is the new behavior?
The `ServeStaticModule` runs  `setHeaders` function also in the 3rd scenario when it serves index.html for unmatched path


## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No

If somebody depended on the current behavior of index.html NOT getting headers ONLY in case when it's served as a fallback for unmatched path then it could be breaing, very hard to imagine such use case though. 
That's why is also hard to sya if it s a bugfix or a feature...
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information