### PR TITLE
fix(fastify) New files requires a server restart to be served

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /.idea
 /.awcache
 /.vscode
+/.history
 
 # misc
 npm-debug.log

--- a/lib/filters/not-found-excepion.filter.ts
+++ b/lib/filters/not-found-excepion.filter.ts
@@ -1,0 +1,72 @@
+import * as fs from 'fs';
+import { validatePath } from '../utils/validate-path.util';
+import {
+  ArgumentsHost,
+  Catch,
+  HttpException,
+  NotFoundException
+} from '@nestjs/common';
+import { ServeStaticModuleOptions } from '../interfaces/serve-static-options.interface';
+import { AbstractLoader } from '../loaders/abstract.loader';
+import {
+    DEFAULT_RENDER_PATH,
+    DEFAULT_ROOT_PATH
+  } from '../serve-static.constants';
+import { BaseExceptionFilter, HttpAdapterHost } from '@nestjs/core';
+import { wildcardToRegExp } from '../utils/wilcard-to-reg-exp.util';
+
+@Catch(NotFoundException)
+export class NotFoundExceptionFilter extends BaseExceptionFilter {
+  constructor(
+    protected httpAdapterHost: HttpAdapterHost,
+    private loader: AbstractLoader,
+    private optionsArr: ServeStaticModuleOptions[]
+  ) {
+      super(httpAdapterHost.httpAdapter);
+  }
+
+  catch(exception: HttpException, host: ArgumentsHost) {
+        const ctx = host.switchToHttp();
+        const response = ctx.getResponse();
+        const request = ctx.getRequest();
+
+        const opts = this.isRenderPath(request);
+
+        if( opts === undefined ){
+            return super.catch(exception, host);
+        }
+
+        opts.renderPath = opts.renderPath || DEFAULT_RENDER_PATH;
+        const clientPath = opts.rootPath || DEFAULT_ROOT_PATH;
+        const indexFilePath = this.loader.getIndexFilePath(clientPath);
+
+        const stream = fs.createReadStream(indexFilePath);
+        if (opts.serveStaticOptions && opts.serveStaticOptions.setHeaders) {
+            const stat = fs.statSync(indexFilePath);
+            opts.serveStaticOptions.setHeaders(response, indexFilePath, stat);
+        }
+        response.type('text/html').send(stream);
+  }
+
+  private isRenderPath(request): ServeStaticModuleOptions | undefined {
+    return this.optionsArr.find( opts => {
+        let renderPath: string | RegExp = opts.renderPath || DEFAULT_RENDER_PATH;
+
+        if( opts.serveRoot ) {
+            renderPath =
+            typeof opts.serveRoot === 'string'
+              ? opts.serveRoot + validatePath(renderPath as string)
+              : opts.serveRoot;
+        }
+
+        const re = renderPath instanceof RegExp ? renderPath : wildcardToRegExp(renderPath);
+        const queryParamsIndex = request.url.indexOf('?');
+        const pathname =
+          queryParamsIndex >= 0
+            ? request.url.slice(0, queryParamsIndex)
+            : request.url;
+    
+        return re.exec(pathname) ? true : false;
+    });
+  }
+}

--- a/lib/loaders/fastify.loader.ts
+++ b/lib/loaders/fastify.loader.ts
@@ -27,41 +27,17 @@ export class FastifyLoader extends AbstractLoader {
       options.renderPath = options.renderPath || DEFAULT_RENDER_PATH;
 
       const clientPath = options.rootPath || DEFAULT_ROOT_PATH;
-      const indexFilePath = this.getIndexFilePath(clientPath);
 
       if (options.serveRoot) {
         app.register(fastifyStatic, {
           root: clientPath,
           ...(options.serveStaticOptions || {}),
-          wildcard: false,
           prefix: options.serveRoot
-        });
-
-        const renderPath =
-          typeof options.serveRoot === 'string'
-            ? options.serveRoot + validatePath(options.renderPath as string)
-            : options.serveRoot;
-
-        app.get(renderPath, (req: any, res: any) => {
-          const stream = fs.createReadStream(indexFilePath);
-          res.type('text/html').send(stream);
         });
       } else {
         app.register(fastifyStatic, {
           root: clientPath,
-          ...(options.serveStaticOptions || {}),
-          wildcard: false
-        });
-        app.get(options.renderPath, (req: any, res: any) => {
-          const stream = fs.createReadStream(indexFilePath);
-          if (
-            options.serveStaticOptions &&
-            options.serveStaticOptions.setHeaders
-          ) {
-            const stat = fs.statSync(indexFilePath);
-            options.serveStaticOptions.setHeaders(res, indexFilePath, stat);
-          }
-          res.type('text/html').send(stream);
+          ...(options.serveStaticOptions || {})
         });
       }
     });

--- a/lib/serve-static.providers.ts
+++ b/lib/serve-static.providers.ts
@@ -1,9 +1,12 @@
 import { Provider } from '@nestjs/common';
-import { HttpAdapterHost } from '@nestjs/core';
+import { APP_FILTER, HttpAdapterHost } from '@nestjs/core';
+import { NotFoundExceptionFilter } from './filters/not-found-excepion.filter';
+import { ServeStaticModuleOptions } from './interfaces/serve-static-options.interface';
 import { AbstractLoader } from './loaders/abstract.loader';
 import { ExpressLoader } from './loaders/express.loader';
 import { FastifyLoader } from './loaders/fastify.loader';
 import { NoopLoader } from './loaders/noop.loader';
+import { SERVE_STATIC_MODULE_OPTIONS } from './serve-static.constants';
 
 export const serveStaticProviders: Provider[] = [
   {
@@ -23,5 +26,13 @@ export const serveStaticProviders: Provider[] = [
       return new ExpressLoader();
     },
     inject: [HttpAdapterHost]
+  },
+  {
+    provide: APP_FILTER,
+    useFactory: (httpAdapterHost: HttpAdapterHost, loader: AbstractLoader, opts: ServeStaticModuleOptions[]) => {
+      if( loader instanceof FastifyLoader )
+        return new NotFoundExceptionFilter(httpAdapterHost, loader, opts);
+    },
+    inject: [HttpAdapterHost, AbstractLoader, SERVE_STATIC_MODULE_OPTIONS]
   }
 ];

--- a/lib/utils/reg-escape.util.ts
+++ b/lib/utils/reg-escape.util.ts
@@ -1,0 +1,5 @@
+/**
+ * Escapes all characters in the given string
+ */
+export const regExpEscape = (s: string) =>
+  s.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&');

--- a/lib/utils/wilcard-to-reg-exp.util.ts
+++ b/lib/utils/wilcard-to-reg-exp.util.ts
@@ -1,0 +1,11 @@
+import { regExpEscape } from "./reg-escape.util";
+
+/**
+ * Creates a RegExp from the given string, allowing wildcards.
+ * 
+ * "*" will be converted to ".*"
+ * "?" will be converted to "."
+ * 
+ * Escapes the rest of the characters
+ */
+export const wildcardToRegExp = (s: string) => new RegExp('^' + s.split(/\*+/).map(regExpEscape).join('.*').replace(/\\\?/g, '.') + '$');


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[X] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

New files are not served using fastify. On [this issue](https://github.com/fastify/fastify-static/issues/161) or in the [documentation of `fastify-static`](https://github.com/fastify/fastify-static#wildcard) is commented that using the `wildcard` option to `false` will create only routes to the current files in the system and it will not serve new files.

The issue was introduced on[ this PR ](https://github.com/nestjs/serve-static/pull/47) due to the fail of the redirection to the index.

## What is the new behavior?

The solution is to remove the `wildcard` option to `false` by default. However, it would create `404` error when the file doesn't exist and it would not redirect to the index. To solve this latest situation, I have caught the 404 error when they are generated under the `renderPath` with the `fastify` adapter to serve the index file, supporting the current behaviour.

## Does this PR introduce a breaking change?
```
[ ] Yes
[X] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information