### PR TITLE
fix(core): Adds express/fastify to peer dependency list and makes them optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   },
   "peerDependencies": {
     "@nestjs/common": "^9.0.0",
-    "@nestjs/core": "^9.0.0"
+    "@nestjs/core": "^9.0.0",
+    "express": "^4.8.1"
   },
   "devDependencies": {
     "@commitlint/cli": "17.1.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,20 @@
   "peerDependencies": {
     "@nestjs/common": "^9.0.0",
     "@nestjs/core": "^9.0.0",
-    "express": "^4.8.1"
+    "express": "^4.18.1",
+    "fastify": "^4.7.0",
+    "@fastify/static": "^6.5.0"
+  },
+  "peerDependenciesMeta": {
+    "express": {
+      "optional": true
+    },
+    "fastify": {
+      "optional": true
+    },
+    "@fastify/static": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@commitlint/cli": "17.1.2",


### PR DESCRIPTION
Adds express/fastify to the peer dependency list to fix a problem with yarn pnp workspaces and resolving dependencies from @nestjs/common through @nestjs/serve-static.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features) **(Not Applicable)**
- [ ] Docs have been added / updated (for bug fixes / features) **(Not Applicable)**

## PR Type
fix: Fixes a Nestjs runtime error saying it cannot find express when using yarn pnp workspaces.

<!-- Please check the one that applies to this PR using "x". -->
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [X] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Receive the error: "The "express" package is missing. Please, make sure to install this library ($ npm install express) to take advantage of ServeStaticModule."

<img width="948" alt="Screen Shot 2022-10-07 at 1 53 13 PM" src="https://user-images.githubusercontent.com/3953314/194650757-0727d0b1-eea9-45a0-aa05-4a5caadb0b1f.png">

Issue Number: N/A


## What is the new behavior?
The `ServeStaticModule` loads properly and this error does not show up.

## Does this PR introduce a breaking change?
- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
