### PR TITLE
Autofix: Update `path-to-regexp` since it's affected by CVE-2024-45296

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "url": "https://github.com/nestjs/serve-static"
   },
   "dependencies": {
-    "path-to-regexp": "0.2.5"
+  "dependencies": {
+    "path-to-regexp": "^6.2.1"
   }
 }


### PR DESCRIPTION
Updated the path-to-regexp dependency to the latest version to address CVE-2024-45296. Changed the version specifier to use caret (^) for better flexibility in consuming projects. 
> [!CAUTION]
> Disclaimer: This fix was created by Latta AI and you should never merge before you check the correctness of generated code!
>
> The fix provided by Latta AI might not be complete and it can serve as an inspiration.

---
This bug was fixed for free by Latta AI - https://latta.ai/ourmission

If you no longer want Latta AI to attempt fixing issues on your repository, you can block this account.
    