### PR TITLE
fix: pass unhandled error on to next express error handler

### DIFF
--- a/lib/loaders/express.loader.ts
+++ b/lib/loaders/express.loader.ts
@@ -83,6 +83,8 @@ export class ExpressLoader extends AbstractLoader {
           throw new NotFoundException(err.message);
         } else if (err?.code === 'ENOENT') {
           throw new NotFoundException(`ENOENT: ${err.message}`);
+        } else {
+          next(err);
         }
       });
     });

--- a/tests/e2e/express-adapter.e2e-spec.ts
+++ b/tests/e2e/express-adapter.e2e-spec.ts
@@ -9,6 +9,24 @@ describe('Express adapter', () => {
   let server: Server;
   let app: INestApplication;
 
+  describe('when middleware throws generic error', () => {
+    beforeAll(async () => {
+      app = await NestFactory.create(AppModule.withDefaults(), {
+        logger: new NoopLogger()
+      });
+      app.use((_req, _res, next) => next(new Error('Something went wrong')));
+
+      server = app.getHttpServer();
+      await app.init();
+    });
+
+    describe('GET /index.html', () => {
+      it('should return Iternal Server Error', async () => {
+        return request(server).get('/index.html').expect(500);
+      });
+    });
+  });
+
   describe('when "fallthrough" option is set to "true"', () => {
     beforeAll(async () => {
       app = await NestFactory.create(AppModule.withFallthrough(), {


### PR DESCRIPTION
Commit 0ae6f5415a81e4ea7daab65650f4015f986afedb introduced an error handling middleware with [this change](https://github.com/nestjs/serve-static/commit/0ae6f5415a81e4ea7daab65650f4015f986afedb#diff-742ebb93a36f6bba7bfedc0f5fe21fc29f05c73aa06bd3a5ab246b0eb001358bR62-R69). However, it does not delegate to the next error handler if it cannot handle the error adequately. This causes the request to hang until a timeout kills the connection. By passing the error on to next, other error handlers (like the default error handler) handle it.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?

A request "hangs" may hang if an error is thrown in some express middleware.
In case `ExpressLoader` does not handle the error in its error handler function,
nothing happens with the request anymore and it hangs until the connection is terminated (e.g. due to timeout).  

Issue Number: N/A (I didn't create a separate issue, let me know I you need that)


## What is the new behavior?

the error handler defined in `ExpressLoader` calls `next(err)`  in case it cannot adequately handle the error.
This way, other error handlers can take care of it.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
