### PR TITLE
`acceptRanges` property

### DIFF
--- a/lib/interfaces/serve-static-options.interface.ts
+++ b/lib/interfaces/serve-static-options.interface.ts
@@ -35,6 +35,12 @@ export interface ServeStaticModuleOptions {
    */
   serveStaticOptions?: {
     /**
+     * Enable or disable accepting ranged requests, defaults to true.
+     * Disabling this will not send Accept-Ranges and ignore the contents of the Range request header.
+     */
+    acceptRanges?: boolean;
+
+    /**
      * Enable or disable setting Cache-Control response header, defaults to true.
      * Disabling this will ignore the immutable and maxAge options.
      */


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A


## What is the new behavior?

This proposed change exposes an existing Express `serve-static` option that is currently not available in this `@nestjs/serve-static` package.

See `acceptRanges` in the `serve-static` docs: https://expressjs.com/en/resources/middleware/serve-static.html




## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

This is an additive change where the native Express `serve-static` property already exists.

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

The areas in which this native Express `serve-static` property would be used are:
1. https://github.com/nestjs/serve-static/blob/afdc74bc943d3b3ff007877c39432652ee17bc5a/lib/loaders/express.loader.ts#L60
2. https://github.com/nestjs/serve-static/blob/afdc74bc943d3b3ff007877c39432652ee17bc5a/lib/loaders/express.loader.ts#L69