### PR TITLE
fix(express): stop replacing upstreaming error with 404

### DIFF
--- a/lib/loaders/express.loader.ts
+++ b/lib/loaders/express.loader.ts
@@ -102,14 +102,14 @@ export class ExpressLoader extends AbstractLoader {
       }
 
       app.use((err: any, req: any, _res: any, next: Function) => {
+        if (err instanceof HttpException) {
+          throw err;
+        }
+
         if (isRouteExcluded(req, options.exclude)) {
           const method = httpAdapter.getRequestMethod(req);
           const url = httpAdapter.getRequestUrl(req);
           return next(new NotFoundException(`Cannot ${method} ${url}`));
-        }
-
-        if (err instanceof HttpException) {
-          throw err;
         } else if (err?.message?.includes('ENOENT')) {
           throw new NotFoundException(err.message);
         } else if (err?.code === 'ENOENT') {

--- a/lib/loaders/express.loader.ts
+++ b/lib/loaders/express.loader.ts
@@ -102,21 +102,33 @@ export class ExpressLoader extends AbstractLoader {
       }
 
       app.use((err: any, req: any, _res: any, next: Function) => {
+        // Anything the application raised is already a deliberate response.
         if (err instanceof HttpException) {
           throw err;
+        }
+
+        const isMissingFile =
+          err?.code === 'ENOENT' || err?.message?.includes('ENOENT');
+
+        // Only a missing file is this middleware's business. Rewriting any
+        // other failure as a 404 would report a genuine server fault as a
+        // client error, so it never reaches an exception filter or 5xx alert.
+        if (!isMissingFile) {
+          return next(err);
         }
 
         if (isRouteExcluded(req, options.exclude)) {
           const method = httpAdapter.getRequestMethod(req);
           const url = httpAdapter.getRequestUrl(req);
+          // Excluded routes report a plain miss instead of the underlying
+          // ENOENT, which would echo the resolved filesystem path back.
           return next(new NotFoundException(`Cannot ${method} ${url}`));
-        } else if (err?.message?.includes('ENOENT')) {
-          throw new NotFoundException(err.message);
-        } else if (err?.code === 'ENOENT') {
-          throw new NotFoundException(`ENOENT: ${err.message}`);
-        } else {
-          next(err);
         }
+
+        if (err.message?.includes('ENOENT')) {
+          throw new NotFoundException(err.message);
+        }
+        throw new NotFoundException(`ENOENT: ${err.message}`);
       });
     });
   }

--- a/tests/e2e/express-adapter.e2e-spec.ts
+++ b/tests/e2e/express-adapter.e2e-spec.ts
@@ -1,4 +1,8 @@
-import { INestApplication, PayloadTooLargeException } from '@nestjs/common';
+import {
+  ConflictException,
+  INestApplication,
+  PayloadTooLargeException
+} from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { Server } from 'net';
 import request from 'supertest';
@@ -335,6 +339,92 @@ describe('Express adapter', () => {
         .get('/api')
         .expect(413)
         .expect(/Payload Too Large/);
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+  });
+
+  describe('when a non-http error happens in the previous middleware', () => {
+    beforeAll(async () => {
+      app = await NestFactory.create(AppModule.withDefaults(), {
+        logger: new NoopLogger()
+      });
+
+      app.use((_req, _res, next) => {
+        next(new TypeError('genuine server fault'));
+      });
+
+      app.setGlobalPrefix('api');
+
+      server = app.getHttpServer();
+      await app.init();
+    });
+
+    // An excluded route must not turn a genuine fault into a 404: that reports
+    // a server error as a client one, so it never trips 5xx alerting.
+    it('should return 500 on an excluded route', async () => {
+      return request(server).get('/api').expect(500);
+    });
+
+    it('should return 500 on a non-excluded route', async () => {
+      return request(server).get('/some/spa/route').expect(500);
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+  });
+
+  describe('when the previous middleware error mentions ENOENT', () => {
+    beforeAll(async () => {
+      app = await NestFactory.create(AppModule.withDefaults(), {
+        logger: new NoopLogger()
+      });
+
+      app.use((_req, _res, next) => {
+        next(new ConflictException('ENOENT: upstream said so'));
+      });
+
+      app.setGlobalPrefix('api');
+
+      server = app.getHttpServer();
+      await app.init();
+    });
+
+    // The static-file handling keys off ENOENT, so an application exception
+    // that merely mentions it must still keep its own status rather than being
+    // rewritten as a 404.
+    it('should keep the original status on an excluded route', async () => {
+      return request(server).get('/api').expect(409);
+    });
+
+    it('should keep the original status on a non-excluded route', async () => {
+      return request(server).get('/some/spa/route').expect(409);
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+  });
+
+  describe('when an excluded route misses a static file', () => {
+    beforeAll(async () => {
+      app = await NestFactory.create(AppModule.withDefaults(), {
+        logger: new NoopLogger()
+      });
+      app.setGlobalPrefix('api');
+
+      server = app.getHttpServer();
+      await app.init();
+    });
+
+    it('should report a plain 404 without leaking the filesystem path', async () => {
+      const response = await request(server).get('/api/404').expect(404);
+
+      expect(response.body.message).toBe('Cannot GET /api/404');
+      expect(JSON.stringify(response.body)).not.toMatch(/ENOENT|client/);
     });
 
     afterAll(async () => {

--- a/tests/e2e/express-adapter.e2e-spec.ts
+++ b/tests/e2e/express-adapter.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { INestApplication } from '@nestjs/common';
+import { INestApplication, PayloadTooLargeException } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { Server } from 'net';
 import request from 'supertest';
@@ -307,6 +307,34 @@ describe('Express adapter', () => {
           .expect(/Not Found/)
           .expect(/Cannot GET \/api\/404/);
       });
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+  });
+
+  describe('when error happens in the previous middleware', () => {
+    beforeAll(async () => {
+      app = await NestFactory.create(AppModule.withDefaults(), {
+        logger: new NoopLogger()
+      });
+
+      app.use((_req, _res, next) => {
+        next(new PayloadTooLargeException());
+      });
+
+      app.setGlobalPrefix('api');
+
+      server = app.getHttpServer();
+      await app.init();
+    });
+
+    it('should return 413', async () => {
+      return request(server)
+        .get('/api')
+        .expect(413)
+        .expect(/Payload Too Large/);
     });
 
     afterAll(async () => {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
If error happens in upstream middleware (e.g. bodyParser throws 413 error) for excluded routes 404 error will be generated which is confusing.

Issue Number: 1729


## What is the new behavior?
Based on commit history found that it is ok to throw original error in case when it is HttpException instance and have "route exclusion" check below

## Does this PR introduce a breaking change?
- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
Addressing issue https://github.com/nestjs/serve-static/issues/1729