### PR TITLE
docs(serve-static): clarify fastify redirect default

### DIFF
--- a/lib/interfaces/serve-static-options.interface.ts
+++ b/lib/interfaces/serve-static-options.interface.ts
@@ -102,7 +102,8 @@ export interface ServeStaticModuleOptions {
     maxAge?: number | string;
 
     /**
-     * Redirect to trailing "/" when the pathname is a dir. Defaults to true.
+     * Redirect to trailing "/" when the pathname is a dir.
+     * Defaults to true when using Express and false when using Fastify.
      */
     redirect?: boolean;
 
@@ -148,8 +149,10 @@ export interface ServeStaticModuleOptionsFactory {
 /**
  * @publicApi
  */
-export interface ServeStaticModuleAsyncOptions
-  extends Pick<ModuleMetadata, 'imports'> {
+export interface ServeStaticModuleAsyncOptions extends Pick<
+  ModuleMetadata,
+  'imports'
+> {
   isGlobal?: boolean;
   useExisting?: Type<ServeStaticModuleOptionsFactory>;
   useClass?: Type<ServeStaticModuleOptionsFactory>;


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Other... Please describe: documentation correction

## What is the current behavior?

The public `serveStaticOptions.redirect` comment says the option defaults to true. That matches Express, but Fastify passes the option through to `@fastify/static`, where the default is false.

Issue Number: Fixes #1885


## What is the new behavior?

The option comment now documents both adapter defaults: true for Express and false for Fastify. Runtime behavior is unchanged.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No


## Other information

Docs-only change; tests were not added because this only corrects the public option documentation.

Validated with:

```bash
npm exec -- prettier --check lib/interfaces/serve-static-options.interface.ts
npm run build
npm run lint
git diff --check
```

Local note: dependency install emitted Node engine warnings because the local runtime was Node 20.18.3 while several dev tools require Node 20.19+ or newer. The listed checks completed after installing the optional oxlint native binding without changing tracked dependency files.