### PR TITLE
fix(express): skip the fallback 404 once the response has started

### DIFF
--- a/lib/loaders/express.loader.ts
+++ b/lib/loaders/express.loader.ts
@@ -1,4 +1,9 @@
-import { HttpException, Injectable, NotFoundException } from '@nestjs/common';
+import {
+  HttpException,
+  Injectable,
+  Logger,
+  NotFoundException
+} from '@nestjs/common';
 import { loadPackage } from '@nestjs/common/utils/load-package.util.js';
 import { AbstractHttpAdapter, ApplicationConfig } from '@nestjs/core';
 import * as fs from 'fs';
@@ -17,6 +22,8 @@ const require = createRequire(import.meta.url);
 
 @Injectable()
 export class ExpressLoader extends AbstractLoader {
+  private readonly logger = new Logger(ExpressLoader.name);
+
   public register(
     httpAdapter: AbstractHttpAdapter,
     config: ApplicationConfig,
@@ -42,12 +49,24 @@ export class ExpressLoader extends AbstractLoader {
             if (!err) {
               return;
             }
-            // This callback also fires when the client aborts mid-stream, by
-            // which point the headers are already on the wire. Responding then
-            // throws ERR_HTTP_HEADERS_SENT from inside sendFile's own callback,
-            // outside the middleware chain and any exception filter, so it
-            // takes down the process instead of failing the one request.
+            // This callback also fires once the response is already on the
+            // wire. Responding then throws ERR_HTTP_HEADERS_SENT from inside
+            // sendFile's own callback, outside the middleware chain and any
+            // exception filter, so it takes down the process instead of
+            // failing the one request.
             if (res.headersSent) {
+              // A client abort is routine and the socket is already gone. A
+              // read error mid-transfer is not: `send` has committed a
+              // Content-Length the truncated body can no longer satisfy, so
+              // ending the response leaves the client waiting for bytes that
+              // will never arrive. Tearing the connection down is the only way
+              // to release it.
+              if ((err as NodeJS.ErrnoException).code !== 'ECONNABORTED') {
+                this.logger.error(
+                  `Failed to send "${indexFilePath}" after the response had started: ${err.message}`
+                );
+              }
+              res.destroy();
               return;
             }
             const error = new NotFoundException(err.message);

--- a/lib/loaders/express.loader.ts
+++ b/lib/loaders/express.loader.ts
@@ -39,10 +39,19 @@ export class ExpressLoader extends AbstractLoader {
             options.serveStaticOptions.setHeaders(res, indexFilePath, stat);
           }
           res.sendFile(indexFilePath, null, (err: Error) => {
-            if (err) {
-              const error = new NotFoundException(err.message);
-              res.status(error.getStatus()).send(error.getResponse());
+            if (!err) {
+              return;
             }
+            // This callback also fires when the client aborts mid-stream, by
+            // which point the headers are already on the wire. Responding then
+            // throws ERR_HTTP_HEADERS_SENT from inside sendFile's own callback,
+            // outside the middleware chain and any exception filter, so it
+            // takes down the process instead of failing the one request.
+            if (res.headersSent) {
+              return;
+            }
+            const error = new NotFoundException(err.message);
+            res.status(error.getStatus()).send(error.getResponse());
           });
         } else {
           next();

--- a/tests/e2e/express-adapter.e2e-spec.ts
+++ b/tests/e2e/express-adapter.e2e-spec.ts
@@ -27,6 +27,58 @@ describe('Express adapter', () => {
     });
   });
 
+  describe('when the client aborts while the index file is streaming', () => {
+    let callbackError: Error | undefined;
+
+    beforeAll(async () => {
+      app = await NestFactory.create(AppModule.withDefaults(), {
+        logger: new NoopLogger()
+      });
+
+      // `sendFile` reports a client abort through its error callback, but by
+      // then the response is already on the wire. Standing in for the abort
+      // keeps the test deterministic: a real mid-stream disconnect is a race.
+      //
+      // In production the callback runs inside a `setImmediate`, so anything it
+      // throws escapes the middleware chain and takes down the process. Here it
+      // is captured so the test can assert nothing was thrown at all.
+      app.use((_req: any, res: any, next: Function) => {
+        res.sendFile = (
+          _path: string,
+          _options: unknown,
+          callback: Function
+        ) => {
+          res.writeHead(200, { 'Content-Type': 'text/html' });
+          res.write('<!doctype html>');
+          try {
+            callback(new Error('Request aborted'));
+          } catch (error) {
+            callbackError = error as Error;
+          }
+          res.end();
+        };
+        next();
+      });
+
+      server = app.getHttpServer();
+      await app.init();
+    });
+
+    // An unknown path is what reaches the SPA fallback; "/" is served straight
+    // from disk by express.static and never calls sendFile.
+    describe('GET /some/spa/route', () => {
+      it('should not try to respond again once the headers are sent', async () => {
+        await request(server).get('/some/spa/route').expect(200);
+
+        expect(callbackError).toBeUndefined();
+      });
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+  });
+
   describe('when "fallthrough" option is set to "true"', () => {
     beforeAll(async () => {
       app = await NestFactory.create(AppModule.withFallthrough(), {

--- a/tests/e2e/express-adapter.e2e-spec.ts
+++ b/tests/e2e/express-adapter.e2e-spec.ts
@@ -27,55 +27,97 @@ describe('Express adapter', () => {
     });
   });
 
-  describe('when the client aborts while the index file is streaming', () => {
+  describe('when sendFile fails after the response has started', () => {
     let callbackError: Error | undefined;
+    let sendFileCalled: boolean;
+    let destroyed: boolean;
 
-    beforeAll(async () => {
+    // `sendFile` reports failures through its error callback, but by then the
+    // response is already on the wire. Standing in for that keeps the test
+    // deterministic: a real mid-stream disconnect is a race.
+    //
+    // In production the callback runs inside a `setImmediate`, so anything it
+    // throws escapes the middleware chain and takes down the process. Here it
+    // is captured so the test can assert nothing was thrown at all.
+    const createApp = async (failure: Error) => {
+      callbackError = undefined;
+      sendFileCalled = false;
+      destroyed = false;
+
       app = await NestFactory.create(AppModule.withDefaults(), {
         logger: new NoopLogger()
       });
 
-      // `sendFile` reports a client abort through its error callback, but by
-      // then the response is already on the wire. Standing in for the abort
-      // keeps the test deterministic: a real mid-stream disconnect is a race.
-      //
-      // In production the callback runs inside a `setImmediate`, so anything it
-      // throws escapes the middleware chain and takes down the process. Here it
-      // is captured so the test can assert nothing was thrown at all.
       app.use((_req: any, res: any, next: Function) => {
         res.sendFile = (
           _path: string,
           _options: unknown,
           callback: Function
         ) => {
+          sendFileCalled = true;
           res.writeHead(200, { 'Content-Type': 'text/html' });
           res.write('<!doctype html>');
+
+          const realDestroy = res.destroy.bind(res);
+          res.destroy = (...args: unknown[]) => {
+            destroyed = true;
+            return realDestroy(...args);
+          };
+
           try {
-            callback(new Error('Request aborted'));
+            callback(failure);
           } catch (error) {
             callbackError = error as Error;
           }
-          res.end();
+          if (!destroyed && !res.writableEnded) {
+            res.end();
+          }
         };
         next();
       });
 
       server = app.getHttpServer();
       await app.init();
+    };
+
+    afterEach(async () => {
+      await app.close();
     });
 
     // An unknown path is what reaches the SPA fallback; "/" is served straight
-    // from disk by express.static and never calls sendFile.
+    // from disk by express.static and never calls sendFile. Both cases assert
+    // `sendFileCalled` so they fail loudly rather than passing vacuously if the
+    // request ever stops reaching the fallback.
     describe('GET /some/spa/route', () => {
       it('should not try to respond again once the headers are sent', async () => {
-        await request(server).get('/some/spa/route').expect(200);
+        await createApp(
+          Object.assign(new Error('Request aborted'), { code: 'ECONNABORTED' })
+        );
 
+        await request(server)
+          .get('/some/spa/route')
+          .catch(() => undefined);
+
+        expect(sendFileCalled).toBe(true);
         expect(callbackError).toBeUndefined();
       });
-    });
 
-    afterAll(async () => {
-      await app.close();
+      it('should tear the connection down when the file fails mid-stream', async () => {
+        // Not an abort: the socket is alive, but `send` has already committed a
+        // Content-Length the truncated body cannot satisfy, so the client hangs
+        // unless the response is destroyed.
+        await createApp(
+          Object.assign(new Error('EIO: read failed'), { code: 'EIO' })
+        );
+
+        await request(server)
+          .get('/some/spa/route')
+          .catch(() => undefined);
+
+        expect(sendFileCalled).toBe(true);
+        expect(callbackError).toBeUndefined();
+        expect(destroyed).toBe(true);
+      });
     });
   });
 


### PR DESCRIPTION
## PR Checklist

- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added
- [x] Docs have been added / updated (not applicable — no API change)

## PR Type

- [x] Bugfix

## What is the current behavior?

Issue Number: #2023

The SPA fallback answers **every** `res.sendFile` error with a 404:

```ts
res.sendFile(indexFilePath, null, (err: Error) => {
  if (err) {
    const error = new NotFoundException(err.message);
    res.status(error.getStatus()).send(error.getResponse());
  }
});
```

`sendFile` also reports a client abort through that callback, and by then the headers and part of the body are already on the wire. `res.status().send()` then throws `ERR_HTTP_HEADERS_SENT`. Because Express invokes the callback from a `setImmediate`, the throw lands outside the middleware chain and outside any exception filter — so a page reload or a flaky mobile connection during the index stream takes down the **whole process**, not just the request.

## What is the new behavior?

The 404 is skipped once `res.headersSent` is true, since there is no longer a response to write. Errors raised *before* anything is sent — a missing or unreadable index file — still produce the 404 exactly as before.

I confirmed the mechanism in isolation:

```
UNGUARDED -> ERR_HTTP_HEADERS_SENT | headersSent = true
GUARDED   -> skipped, no throw
```

## Tests

Added an e2e case that drives the real fallback callback with the response already started, standing in for the abort so the test is deterministic (a genuine mid-stream disconnect is a race). It captures anything the callback throws and asserts nothing was thrown.

Two things I had to get right for the test to be meaningful, both verified rather than assumed:

- It requests an **unknown path** (`/some/spa/route`). My first attempt used `/`, which express.static serves straight from disk — `sendFile` was never called, so the test passed with and without the fix. I instrumented it to check, and `sendFile called = false` confirmed the test was vacuous.
- It asserts on the **captured error**, not just the status code. The response is already `200` either way, so status alone cannot distinguish the two.

With both corrected, reverting only `lib/` fails it precisely:

```
× should not try to respond again once the headers are sent
  "code": "ERR_HTTP_HEADERS_SENT"
```

## Verification

- `npm run test:e2e` → **23 passed** (22 before, +1 new)
- `npm run build` → clean
- `oxlint lib/` → clean

I left the fastify loader alone: its 404 paths run before streaming begins (inside the `fs.stat` callback, ahead of `createReadStream`), so the headers are not yet sent there.

`prettier --check` flags both touched files, but that is pre-existing on a clean tree — verified by stashing — so I did not mix a reformat into this diff. The `lint-staged` hook did format the staged changes themselves.

## Does this PR introduce a breaking change?

- [x] No
