### PR TITLE
fix(express): avoid leaking filesystem paths in missing-file responses

### DIFF
--- a/lib/loaders/express.loader.ts
+++ b/lib/loaders/express.loader.ts
@@ -69,7 +69,11 @@ export class ExpressLoader extends AbstractLoader {
               res.destroy();
               return;
             }
-            const error = new NotFoundException(err.message);
+            // Report a plain miss rather than the underlying ENOENT, whose
+            // message echoes the resolved filesystem path back to the client.
+            const method = httpAdapter.getRequestMethod(req);
+            const url = httpAdapter.getRequestUrl(req);
+            const error = new NotFoundException(`Cannot ${method} ${url}`);
             res.status(error.getStatus()).send(error.getResponse());
           });
         } else {

--- a/lib/loaders/express.loader.ts
+++ b/lib/loaders/express.loader.ts
@@ -117,18 +117,11 @@ export class ExpressLoader extends AbstractLoader {
           return next(err);
         }
 
-        if (isRouteExcluded(req, options.exclude)) {
-          const method = httpAdapter.getRequestMethod(req);
-          const url = httpAdapter.getRequestUrl(req);
-          // Excluded routes report a plain miss instead of the underlying
-          // ENOENT, which would echo the resolved filesystem path back.
-          return next(new NotFoundException(`Cannot ${method} ${url}`));
-        }
-
-        if (err.message?.includes('ENOENT')) {
-          throw new NotFoundException(err.message);
-        }
-        throw new NotFoundException(`ENOENT: ${err.message}`);
+        // Report a plain miss rather than the underlying ENOENT, whose
+        // message echoes the resolved filesystem path back to the client.
+        const method = httpAdapter.getRequestMethod(req);
+        const url = httpAdapter.getRequestUrl(req);
+        return next(new NotFoundException(`Cannot ${method} ${url}`));
       });
     });
   }

--- a/tests/e2e/express-adapter.e2e-spec.ts
+++ b/tests/e2e/express-adapter.e2e-spec.ts
@@ -431,4 +431,26 @@ describe('Express adapter', () => {
       await app.close();
     });
   });
+
+  describe('when the SPA fallback index.html is missing', () => {
+    beforeAll(async () => {
+      app = await NestFactory.create(AppModule.withMissingIndex(), {
+        logger: new NoopLogger()
+      });
+
+      server = app.getHttpServer();
+      await app.init();
+    });
+
+    it('should not leak the filesystem path', async () => {
+      const response = await request(server).get('/some-spa-route').expect(404);
+
+      expect(JSON.stringify(response.body)).not.toMatch(/ENOENT|nonexistent/);
+      expect(response.body.message).toMatch(/Cannot GET/);
+    });
+
+    afterAll(async () => {
+      await app.close();
+    });
+  });
 });

--- a/tests/e2e/express-adapter.e2e-spec.ts
+++ b/tests/e2e/express-adapter.e2e-spec.ts
@@ -299,7 +299,7 @@ describe('Express adapter', () => {
           .get('/404')
           .expect(404)
           .expect(/Not Found/)
-          .expect(/ENOENT/);
+          .expect(/Cannot GET \/404/);
       });
     });
 

--- a/tests/src/app.module.ts
+++ b/tests/src/app.module.ts
@@ -61,6 +61,17 @@ export class AppModule {
     };
   }
 
+  static withMissingIndex() {
+    return {
+      module: AppModule,
+      imports: [
+        ServeStaticModule.forRoot({
+          rootPath: join(import.meta.dirname, '..', 'client', 'nonexistent')
+        })
+      ]
+    };
+  }
+
   // A global pattern is stateful under `RegExp.prototype.test`, so this fixture
   // guards against the exclusion alternating between requests.
   static withGlobalRegexExclude() {


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

In the Express loader's static-file error middleware, a missing-file error is handled differently depending on whether the request hit an excluded route:

- On an **excluded** route, the error is replaced with a plain `Cannot GET /path` message.
- On a **non-excluded** route, the raw `ENOENT` error message is sent to the client as-is. That message includes the absolute filesystem path resolved by `express.static`/`send` (e.g. `ENOENT: no such file or directory, stat '/home/deploy/app/client/secret.txt'`), so requesting any non-existent path discloses the server's deployment directory structure.

This inconsistency looks unintentional: the excluded-route branch already exists specifically to avoid this leak (see the comment introduced in 488e252), but the non-excluded branch was never brought in line with it.

## What is the new behavior?

Non-excluded routes now report the same plain `Cannot GET /path` message as excluded routes, instead of the raw `ENOENT`/error message. This matches the Fastify loader, which never echoes the underlying filesystem error to the client either.

The missing-file detection (`err.code === 'ENOENT' || err.message.includes('ENOENT')`) and the `HttpException` / non-missing-file guards above it are unchanged — this PR only touches what happens once an error has already been classified as a missing file.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

The only observable difference is that the 404 response body for a missing static file on a non-excluded route no longer contains the resolved filesystem path — it now reads `Cannot GET /path`, consistent with the excluded-route behavior already in place. The existing e2e test asserting `/ENOENT/` in that response body has been updated to assert the new message instead.

## Other information

This doesn't grant file access outside the configured static root and isn't a path-traversal issue — it's an information-disclosure hardening: the server's absolute deployment path (directory layout, OS username, etc.) was previously echoed back to any client requesting a non-existent path on a non-excluded route.